### PR TITLE
Fix ack_len

### DIFF
--- a/arm_iop/source/wifi_card.twl.c
+++ b/arm_iop/source/wifi_card.twl.c
@@ -814,6 +814,10 @@ u16 wifi_card_mbox0_readpkt(void)
 #endif
     
     u8 ack_len = read_buffer[4];
+	if (!ack_present) {
+		// ack_len can be set to 0xFF sometimes when an ack is not present, resulting in erroneous data...!
+		ack_len = 0;
+	}
     u16 len_pkt = len - ack_len;
     u16 pkt_cmd = *(u16*)&read_buffer[6];
     u8* pkt_data = &read_buffer[8];


### PR DESCRIPTION
Fixes some routers not being able to connect. ack_len tended to be set to 0xFF on broadcast packets, despite not having any ack data, which would result in a negative packet size if the packet was shorter than 0xFF. This would cause it to not process the packet correctly; the fact that larger packets processed correctly is somewhat of a mystery to me as they theoretically should've bailed early as well, but it's likely it's just a certain threshold before it stops working.